### PR TITLE
chore: use Go 1.22 for lambda modules

### DIFF
--- a/lambda/connect/go.mod
+++ b/lambda/connect/go.mod
@@ -1,6 +1,6 @@
 module chatapp/connect
 
-go 1.23.5
+go 1.22
 
 require (
 	github.com/aws/aws-lambda-go v1.49.0 // indirect

--- a/lambda/disconnect/go.mod
+++ b/lambda/disconnect/go.mod
@@ -1,6 +1,6 @@
 module chatapp/disconnect
 
-go 1.23.5
+go 1.22
 
 require (
 	github.com/aws/aws-lambda-go v1.49.0 // indirect

--- a/lambda/send/go.mod
+++ b/lambda/send/go.mod
@@ -1,6 +1,6 @@
 module chatapp/send
 
-go 1.23.5
+go 1.22
 
 require (
 	github.com/aws/aws-lambda-go v1.49.0


### PR DESCRIPTION
## Summary
- use stable Go 1.22 in connect, disconnect and send lambdas

## Testing
- `for dir in connect disconnect send; do (cd lambda/$dir && go mod tidy); done` *(fails: Forbidden)*
- `for dir in connect disconnect send; do (cd lambda/$dir && GOPROXY=direct GONOSUMDB=github.com/stretchr/testify go mod tidy); done` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6562f94ac8327bce9cb931b9e2c04